### PR TITLE
Fix typos/spelling

### DIFF
--- a/documentation/comparison.md
+++ b/documentation/comparison.md
@@ -12,9 +12,9 @@ The biggest difference might be that Solid is built on S.js which has explicit m
 
 ## React
 
-React is also has had a big influence on Solid. It's unidirectional flow and explicit segregation of read and write in it's Hooks API informed Solid's API. More so the objective of being just a "Render Library" rather than a framework. Solid has strong opinions on how to approach managing data in application development but doesn't seek to constrain it's execution.
+React is also has had a big influence on Solid. Its unidirectional flow and explicit segregation of read and write in it's Hooks API informed Solid's API. More so the objective of being just a "Render Library" rather than a framework. Solid has strong opinions on how to approach managing data in application development but doesn't seek to constrain it's execution.
 
-However, as much as Solid aligns with React's design philosophy, it works significantly different fundamentally. React uses a Virtual DOM, and Solid does not. React's abstraction is top down component partition where render methods are called repeatedly and diffed. Whereas Solid renders each Template once in entirity constructing it's reactive graph and afterwords only executes instructions related to fine-grained changes.
+However, as much as Solid aligns with React's design philosophy, it works significantly different fundamentally. React uses a Virtual DOM, and Solid does not. React's abstraction is top down component partition where render methods are called repeatedly and diffed. Whereas Solid renders each Template once in entirety constructing it's reactive graph and afterwords only executes instructions related to fine-grained changes.
 
 ## Svelte
 
@@ -28,13 +28,13 @@ Svelte still represents pushing the boundaries of precompilation where Solid is 
 
 These libraries are incredibly similar and have had some influence on Solid. Mostly that Solid's compiled code uses a very similar method to performantly initially render the DOM. Cloning Template elements and using comment placeholders are something that Solid and these libraries share in common.
 
-The biggest difference is that while these libraries do not use the Virtual DOM they treat rendering the same way, top down and requiring component partitioning to keep things sane. By contrast Solid uses it's fine grained Reactive Graph to only update what has changed and in so only shares this technique for it's initial render. This allows for it benefit from the initial speed only available from native DOM and also have the most performant approach to updates.
+The biggest difference is that while these libraries do not use the Virtual DOM they treat rendering the same way, top down and requiring component partitioning to keep things sane. By contrast Solid uses its fine grained Reactive Graph to only update what has changed and in so only shares this technique for its initial render. This allows for it benefit from the initial speed only available from native DOM and also have the most performant approach to updates.
 
 ## Vue
 
-Solid is not particularly influenced by Vue, but they are relatable. They both use Proxies over a Reactive system, but that is where the similarities end. Vue's fine grained dependency detection just feeds into a less fine-grained Virtual DOM and Component system whereas Solid keeps it's granularity right down to it's direct DOM updates.
+Solid is not particularly influenced by Vue, but they are relatable. They both use Proxies over a Reactive system, but that is where the similarities end. Vue's fine grained dependency detection just feeds into a less fine-grained Virtual DOM and Component system whereas Solid keeps its granularity right down to its direct DOM updates.
 
-Vue works off configuration objects where Solid uses a more functional approach instead opting for composeable primitives. Vue credits it's configuration as an easy learning curve, but we feel having fewer simple primitives actually reduces mental overhead in a similar way. Where configuration objects or lifecycles require learning and remember how they apply(like a checklist), Solid's primitives are not unlike understanding what Array.map does. Once you have the tool you can do the job.
+Vue works off configuration objects where Solid uses a more functional approach instead opting for composeable primitives. Vue credits its configuration as an easy learning curve, but we feel having fewer simple primitives actually reduces mental overhead in a similar way. Where configuration objects or lifecycles require learning and remember how they apply(like a checklist), Solid's primitives are not unlike understanding what Array.map does. Once you have the tool you can do the job.
 
 Vue also is setup for direct mutation and 2 way binding, which helps keep the code small. However, Solid's functional approach often leads to less setup than Vue's configuration objects.
 


### PR DESCRIPTION
Was reading through the docs and getting excited about the project, but got distracted by the `it's/its` typos.

It's is a contraction of 'it' and 'is', 'its' is defined as: "belonging to or associated with a thing previously mentioned or easily identified"