### PR TITLE
Improved wrapped type definitions (support for Date and functions)

### DIFF
--- a/src/state.ts
+++ b/src/state.ts
@@ -16,8 +16,8 @@ type AddSymbolToPrimitive<T> = T extends
   {[Symbol.toPrimitive]: V;} :
   {};
 type AddCallable<T> = T extends
-  {(...x: any): infer V;} ?
-  {(...x: any): V;} :
+  {(...x: any[]): infer V;} ?
+  {(...x: Parameters<T>): V;} :
   {};
 
 export type Wrapped<T> = {

--- a/src/state.ts
+++ b/src/state.ts
@@ -9,9 +9,24 @@ type StateNode = {
   [k: number]: any
 }
 type Partial<T> = { [P in keyof T]?: Partial<T[P]> }
+
+// well-known symbols need special treatment until https://github.com/microsoft/TypeScript/issues/24622 is implemented.
+type AddSymbolToPrimitive<T> = T extends
+  {[Symbol.toPrimitive]: infer V;} ?
+  {[Symbol.toPrimitive]: V;} :
+  {};
+type AddCallable<T> = T extends
+  {(...x: any): infer V;} ?
+  {(...x: any): V;} :
+  {};
+
 export type Wrapped<T> = {
   [P in keyof T]: T[P] extends object ? Wrapped<T[P]> : T[P];
-} & { _state: T }
+} & {
+  _state: T
+} & AddSymbolToPrimitive<T>
+  & AddCallable<T>;
+
 type StateAtom = string | number | boolean | symbol | null | undefined | any[]
 type StateSetter<T> = (
   Partial<T>


### PR DESCRIPTION
The `Wrapped<T>` type definition is still missing a few pieces to fully work in general. I first noticed this when working with `Date`, which always required manual casts because of the `Symbol.toPrimitive` symbol. I had to [ask for help](https://stackoverflow.com/questions/57100616/how-to-forward-well-known-symbols-in-a-type-wrapper-mapped-type) in order to come up with a solution. To make other well-known symbols work, we could either add more explicitly forwarded definitions, or wait until the [upstream TS issue](https://github.com/microsoft/TypeScript/issues/24622) gets a release (had recent activity, so may be available soon).

I also may have to refine the forwarding of `AddCallable`, but if you don't mind I'd first experiment with this change for a while and make necessary improvements step-by-step.