### PR TITLE
Improved readability of control flow function signatures

### DIFF
--- a/src/dom/index.ts
+++ b/src/dom/index.ts
@@ -13,20 +13,38 @@ export function render(code: () => any, element: Node): () => void {
   return disposer!;
 }
 
-export function For<T, U>(props: {each: T[], fallback?: any, transform?: (mapped: () => U[], source: () => T[]) => () => U[], children: (item: T) => U }) {
-  const mapped = map<T, U>(props.children, 'fallback' in props ? () => props.fallback : undefined)(() => props.each);
+export function For<T, U>(
+    props: {
+      each: T[],
+      fallback?: any,
+      transform?: (mapped: () => U[], source: () => T[]) => () => U[],
+      children: (item: T) => U,
+    }) {
+  const mapped = map<T, U>(
+    props.children, 'fallback' in props ? () => props.fallback : undefined
+  )(() => props.each);
   return props.transform ? props.transform(mapped, () => props.each) : mapped;
 }
 
-export function Show<T>(props: {when: boolean, fallback?: any, transform?: (mapped: () => T, source: () => boolean) => () => T | undefined, children: any }) {
+export function Show<T>(
+    props: {
+      when: boolean,
+      fallback?: any,
+      transform?: (mapped: () => T, source: () => boolean) => () => T | undefined,
+      children: any,
+    }) {
   const condition = createMemo(() => props.when, undefined, EQUAL),
     useFallback = 'fallback' in props,
     mapped = () => condition() ? sample(() => props.children) : useFallback && sample(() => props.fallback)
   return props.transform ? props.transform(mapped, condition) : mapped;
 }
 
-type MatchProps = { when: boolean, children: any }
-export function Switch<T>(props: { fallback?: any, transform: (mapped: () => T, source: () => number) => () => T, children: any }) {
+export function Switch<T>(
+    props: {
+      fallback?: any,
+      transform?: (mapped: () => T, source: () => number) => () => T,
+      children: any,
+    }) {
   let conditions = props.children;
   Array.isArray(conditions) || (conditions = [conditions]);
   const useFallback = 'fallback' in props,
@@ -43,9 +61,15 @@ export function Switch<T>(props: { fallback?: any, transform: (mapped: () => T, 
   return props.transform ? props.transform(mapped, evalConditions) : mapped;
 }
 
+type MatchProps = { when: boolean, children: any }
 export function Match(props: MatchProps) { return props; }
 
-export function Suspense(props: { delayMs?: number, fallback: any, children: any }) {
+export function Suspense(
+    props: {
+      delayMs?: number,
+      fallback: any,
+      children: any,
+    }) {
   return createComponent(SuspenseContext.Provide, { value: props.delayMs,  children: () => {
     const c = useContext(SuspenseContext),
       rendered = sample(() => props.children),
@@ -64,7 +88,12 @@ export function Suspense(props: { delayMs?: number, fallback: any, children: any
   }}, ['children']);
 }
 
-export function Portal(props: {mount?: Node, useShadow: boolean, children: any}) {
+export function Portal(
+    props: {
+      mount?: Node,
+      useShadow: boolean,
+      children: any,
+    }) {
   const { useShadow } = props,
     container =  document.createElement('div'),
     marker = document.createTextNode(''),


### PR DESCRIPTION
This PR is just a minor code reformatting. I was trying to read the function signatures on GitHub and it was very hard to read because of having everything in one line:

![Peek 2019-07-21 11-10](https://user-images.githubusercontent.com/3620703/61589364-16b08280-aba9-11e9-951d-fa7119023827.gif)

Since they are public interface good readability would be nice. Also leads to better git diffs, but feel free to reject this PR if the shorter lines are just too far away from your personal taste ;).

The only functional change included in the PR is that I added a `?` to the `transform` of `Switch`. I guess it was not intended to make it mandatory, was it?