### PR TITLE
more type safety in control flow elements

### DIFF
--- a/src/dom/index.ts
+++ b/src/dom/index.ts
@@ -52,9 +52,9 @@ export function Show(props: {
 export function Switch(props: {
   fallback?: JSX.Element;
   transform?: (mapped: () => JSX.Element, source: () => number) => () => JSX.Element;
-  children: JSX.MatchElement[];
+  children: JSX.MatchElement | JSX.MatchElement[];
 }): JSX.Element {
-  let conditions = props.children;
+  let conditions = props.children as JSX.MatchElement[];
   Array.isArray(conditions) || (conditions = [conditions]);
   const useFallback = "fallback" in props,
     evalConditions = createMemo(

--- a/src/dom/index.ts
+++ b/src/dom/index.ts
@@ -76,7 +76,7 @@ export function Switch(props: {
   return props.transform ? props.transform(mapped, evalConditions) : mapped;
 }
 
-type MatchProps = { when: boolean; children: any };
+type MatchProps = { when: boolean; children: JSX.Element };
 export function Match(props: MatchProps): JSX.Element {
   return props;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,10 @@
     "newLine": "LF",
     "incremental": true,
     "moduleResolution": "node",
-    "strict": true
+    "strict": true,
+    "types": [
+      "node",
+      "./node_modules/babel-plugin-jsx-dom-expressions"
+    ]
   }
 }


### PR DESCRIPTION
I have adjusted the control flow type signatures based on the refined `JSX.Element` type. The compiler has already revealed a few interesting things:

- I tried to remove most of the `any` in the control flow signatures to actually make use of the compiler.
- In some cases a value `false` can be returned, which was not on the list of allowed values you mentioned. This currently requires `as any as JSX.Element` casts. If this is legal we can add it to the `JSX.Element` definition.
- The show control flow allowed transforms to undefined, which is also not supported so far. I've removed the possibility to have an undefined return value.
- The switch element would have bugs it gets arbitrary JSX children, only one or multiple match elements seem to work. I have narrowed down the allowed children to that.
- The portal element currently doesn't fit into the JSX.Element type. I have left it out so far.
- There was a compilation error in `suspense.ts` which I have fixed by adding NodeJS types (but does `NodeJS.Timeout` work in the browser?).

If you feel uneasy of narrowing down the types at this moment, feel free to keep the PR open for now. I can update it as Solid continues to develop. Just wanted to give you an impression how it could look eventually.