### PR TITLE
Don’t use optional parameters in callbacks

### DIFF
--- a/src/dom/index.ts
+++ b/src/dom/index.ts
@@ -51,7 +51,7 @@ export function Show<T>(props: {
     mapped = () =>
       condition()
         ? sample(() => props.children)
-        : useFallback ? sample(() => props.fallback): undefined;
+        : useFallback ? sample(() => props.fallback) : undefined;
   return props.transform ? props.transform(mapped, condition) : mapped;
 }
 

--- a/src/dom/index.ts
+++ b/src/dom/index.ts
@@ -31,7 +31,7 @@ export function For<T, U>(props: {
   each: T[];
   fallback?: any;
   transform?: (mapped: () => U[], source: () => T[]) => () => U[];
-  children: (item: T, index?: number) => U;
+  children: (item: T, index: number) => U;
 }) {
   const mapped = map<T, U>(
     props.children,

--- a/src/operator.ts
+++ b/src/operator.ts
@@ -85,7 +85,7 @@ export function pipe(...fns: Array<Operator<any, any>>): Operator<any, any> {
 }
 
 // Modified version of mapSample from S-array[https://github.com/adamhaile/S-array] by Adam Haile
-export function map<T, U>(mapFn: (v: T, i?: number) => U, fallback?: () => U) {
+export function map<T, U>(mapFn: (v: T, i: number) => U, fallback?: () => U) {
   return (list: () => T[]) => {
     let items = [] as T[],
       mapped = [] as U[],


### PR DESCRIPTION
See this: https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html#optional-parameters-in-callbacks.

(May require more changes, just made this to point this out)