### PR TITLE
mismatch obj key

### DIFF
--- a/documentation/state.md
+++ b/documentation/state.md
@@ -76,7 +76,7 @@ setState('todos', { from: 0, to: 1 }, 'completed', c => !c);
 //   ]
 // }
 
-setState('todos', todo => todo.completed, 'title', t => t + '!')
+setState('todos', todo => todo.completed, 'task', t => t + '!')
 // {
 //   todos: [
 //     { task: 'Finish work', completed: false }


### PR DESCRIPTION
the passed in todo obj uses `task` as the key. the ex. uses `title`.... a typo?