### PR TITLE
Remove lots of type casts

### DIFF
--- a/src/dom/h.ts
+++ b/src/dom/h.ts
@@ -2,4 +2,4 @@
 import { createHyperScript } from "hyper-dom-expressions";
 import * as r from "./index";
 
-export default createHyperScript(r as any);
+export default createHyperScript(r);

--- a/src/dom/html.ts
+++ b/src/dom/html.ts
@@ -2,4 +2,4 @@
 import { createHTML } from "lit-dom-expressions";
 import * as r from "./index";
 
-export default createHTML(r as any);
+export default createHTML(r);

--- a/src/dom/transform.ts
+++ b/src/dom/transform.ts
@@ -23,13 +23,13 @@ export function selectWhen(
   handler: any
 ): (s: () => any) => () => any {
   if (typeof handler === "string") handler = createHandler(handler);
-  return list => {
+  return (list: () => any[]) => {
     createEffect(element => {
       const model = signal();
       if (element) handler(element, false);
       if (
         (element =
-          model && sample(list as () => any[]).find(el => el.model === model))
+          model && sample(list).find(el => el.model === model))
       )
         handler(element, true);
       return element;
@@ -51,10 +51,10 @@ export function selectEach(
   handler: any
 ): (s: () => any) => () => any {
   if (typeof handler === "string") handler = createHandler(handler);
-  return list => {
+  return (list: () => any[]) => {
     createEffect<Element[]>((elements = []) => {
       const models = signal(),
-        newElements = sample(list as () => any[]).filter(
+        newElements = sample(list).filter(
           el => models.indexOf(el.model) > -1
         ),
         [additions, removals] = shallowDiff(newElements, elements!);

--- a/src/operator.ts
+++ b/src/operator.ts
@@ -87,7 +87,7 @@ export function pipe(...fns: Array<Operator<any, any>>): Operator<any, any> {
 // Modified version of mapSample from S-array[https://github.com/adamhaile/S-array] by Adam Haile
 export function map<T, U>(mapFn: (v: T, i: number) => U, fallback?: () => U) {
   return (list: () => T[]) => {
-    let items = [] as T[],
+    let items = [] as (T | typeof FALLBACK)[],
       mapped = [] as U[],
       disposers = [] as (() => void)[],
       len = 0;
@@ -101,14 +101,14 @@ export function map<T, U>(mapFn: (v: T, i: number) => U, fallback?: () => U) {
         j: number;
       return sample(() => {
         let newLen = newItems.length,
-          newIndices: Map<T, number>,
+          newIndices: Map<T | typeof FALLBACK, number>,
           newIndicesNext: number[],
           temp: U[],
           tempdisposers: (() => void)[],
           start: number,
           end: number,
           newEnd: number,
-          item: T;
+          item: T | typeof FALLBACK;
 
         // fast path for empty arrays
         if (newLen === 0) {
@@ -120,7 +120,7 @@ export function map<T, U>(mapFn: (v: T, i: number) => U, fallback?: () => U) {
             len = 0;
           }
           if (fallback) {
-            items = [(FALLBACK as unknown) as any];
+            items = [FALLBACK];
             mapped[0] = createRoot(disposer => {
               disposers[0] = disposer;
               return fallback();

--- a/src/signal.ts
+++ b/src/signal.ts
@@ -302,10 +302,10 @@ type Log = {
 };
 function createLog(): Log {
   return {
-    node1: null as null | ComputationNode,
+    node1: null,
     node1slot: 0,
-    nodes: null as null | ComputationNode[],
-    nodeslots: null as null | number[]
+    nodes: null,
+    nodeslots: null
   };
 }
 

--- a/src/signal.ts
+++ b/src/signal.ts
@@ -40,7 +40,7 @@ export function createDependentEffect<T>(
   if (Array.isArray(deps)) deps = callAll(deps);
   defer = !!defer;
 
-  createEffect((value: T | undefined) => {
+  createEffect<T | undefined>((value: T | undefined) => {
     const listener = Listener;
     deps();
     if (defer) defer = false;
@@ -49,7 +49,7 @@ export function createDependentEffect<T>(
       value = fn(value);
       Listener = listener;
     }
-    return value as T;
+    return value;
   });
 }
 

--- a/src/signal.ts
+++ b/src/signal.ts
@@ -107,7 +107,9 @@ export function createRoot<T>(
 
   try {
     Listener = null;
-    result = disposer === null ? (fn as any)() : fn(disposer);
+    // TS does not support `if (fn.length === 0) { fn(); }`
+    // therefore this rather ugly type cast is needed.
+    result = disposer === null ? (fn as (() => T)) () : fn(disposer);
   } finally {
     Listener = listener;
     Owner = root.owner;

--- a/src/signal.ts
+++ b/src/signal.ts
@@ -419,7 +419,7 @@ function makeComputationNode<T>(
   node.comparator = comparator;
   Owner = node;
   Listener = sample ? null : node;
-  value = toplevel ? execToplevelComputation(fn, value as T) : fn(value);
+  value = toplevel ? execToplevelComputation(fn, value) : fn(value);
   Owner = node.owner;
   Listener = listener;
 
@@ -431,7 +431,7 @@ function makeComputationNode<T>(
   return makeComputationNodeResult;
 }
 
-function execToplevelComputation<T>(fn: (v: T | undefined) => T, value: T) {
+function execToplevelComputation<T>(fn: (v: T | undefined) => T, value?: T) {
   RunningClock = RootClock;
   RootClock.changes.reset();
   RootClock.updates.reset();

--- a/src/signal.ts
+++ b/src/signal.ts
@@ -115,7 +115,7 @@ export function createRoot<T>(
 
   if (
     disposer !== null &&
-    recycleOrClaimNode(root, null as any, undefined, true)
+    recycleOrClaimNode(root, null, undefined, true)
   ) {
     root = null!;
   }
@@ -471,7 +471,7 @@ function getCandidateNode() {
 
 function recycleOrClaimNode<T>(
   node: ComputationNode,
-  fn: (v: T | undefined) => T,
+  fn: ((v: T | undefined) => T) | null,
   value: T,
   orphan: boolean
 ) {

--- a/src/state.ts
+++ b/src/state.ts
@@ -154,12 +154,12 @@ export function setProperty(
   value: any,
   force?: boolean
 ) {
-  value = unwrap(value) as StateNode;
-  if (!force && state[property] === value) return;
+  let unwrappedValue = unwrap(value);
+  if (!force && state[property] === unwrappedValue) return;
   const notify = Array.isArray(state) || !(property in state);
-  if (value === void 0) {
+  if (unwrappedValue === void 0) {
     delete state[property];
-  } else state[property] = value;
+  } else state[property] = unwrappedValue;
   let nodes = getDataNodes(state),
     node;
   (node = nodes[property]) && node.next();


### PR DESCRIPTION
I removed almost all explicit type casts (`x as Y`) as they weren't needed or could be expressed in a different way. The code still contains a lot of implicit type casts because `any` is used a lot.