### PR TITLE
Improved Context type definitions

### DIFF
--- a/src/signal.ts
+++ b/src/signal.ts
@@ -176,17 +176,20 @@ export function isListening() {
 }
 
 // context API
-export interface Context {
+export interface Context<T = any> {
   id: symbol;
-  Provider: (props: any) => any;
-  defaultValue: unknown;
+  Provider: (props: { value: T; children: any }) => any;
+  defaultValue: T;
 }
-export function createContext(defaultValue?: unknown): Context {
+
+export function createContext<T = any>(): Context<T | undefined>;
+export function createContext<T = any>(defaultValue: T): Context<T>;
+export function createContext(defaultValue?: any): Context<any> {
   const id = Symbol("context");
   return { id, Provider: createProvider(id), defaultValue };
 }
 
-export function useContext(context: Context) {
+export function useContext<T>(context: Context<T>): T {
   return lookup(Owner, context.id) || context.defaultValue;
 }
 


### PR DESCRIPTION
This patch makes it much easier to use Context in a type-safe manner. I aimed to make it as backward compatible as possible but as with any change that makes types stricter there is a possibily of a break.

Patterns that do _not_ need to change after the patch:

```ts
// 1. Specifying Context as a type without the generic parameter
const a: Context = ...;

// 2. Creating a context with an undefined default value
const SomeContext = createContext();
const value = useContext(SomeContext);
if (value) {
  // Accessing any parameter on a context that was created without a default value
  value.increment();
}

// 3. Accessing values on a context created with a default value
const SomeContext = createContext({ foo: "" });
const { foo } = useContext(SomeContext);
```

The only breaking changes I could think of:

```ts
// 1. Accessing a property that was not present on the default value of the context
const SomeContext = createContext({ foo: "" });
const value = useContext(SomeContext);
console.log(value.bar); // Error, would compile previously

// 2. TS inferring a more general type that intended
function test(x: "test") {}
const SomeContext = createContext({ foo: "test" });
const { foo } = useContext(SomeContext);
test(foo); // Error, would compile previously
```

I could also make the typings stricter by omitting the default `T = any` generic parameters if you'd like, I just wanted to make the more conservative version first.