### PR TITLE
Update MountableElement type so it accepts more actually-mountable types

### DIFF
--- a/packages/solid/src/dom/index.ts
+++ b/packages/solid/src/dom/index.ts
@@ -13,7 +13,7 @@ import {
   equalFn
 } from "../index.js";
 
-type MountableElement = Element | Document | ShadowRoot | DocumentFragment;
+type MountableElement = Node;
 
 export function render(code: () => any, element: MountableElement): () => void {
   let disposer: () => void;


### PR DESCRIPTION
Node is the common class between all mountable nodes. DocumentFragment is a direct subclass of Node for example.