### PR TITLE
Update solid-rx's solid-js peer dependency to the latest version

### DIFF
--- a/packages/solid-rx/package.json
+++ b/packages/solid-rx/package.json
@@ -26,7 +26,7 @@
     "url": "https://github.com/ryansolid/solid/issues"
   },
   "peerDependencies": {
-    "solid-js": "^0.15.5"
+    "solid-js": "^0.18.0"
   },
   "devDependencies": {
     "solid-js": "^0.18.0"


### PR DESCRIPTION
When I install solid-rx 0.18 with solid-js 0.18, yarn gives me the following warning: solid-rx@0.18.0" has incorrect peer dependency "solid-js@^0.15.5".  This change updates the solid-js peer dependency to 0.18 to fix the warning.