### PR TITLE
Update to latest version of coveralls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4296,16 +4296,16 @@
 			}
 		},
 		"coveralls": {
-			"version": "3.0.11",
-			"resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.11.tgz",
-			"integrity": "sha512-LZPWPR2NyGKyaABnc49dR0fpeP6UqhvGq4B5nUrTQ1UBy55z96+ga7r+/ChMdMJUwBgyJDXBi88UBgz2rs9IiQ==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.1.0.tgz",
+			"integrity": "sha512-sHxOu2ELzW8/NC1UP5XVLbZDzO4S3VxfFye3XYCznopHy02YjNkHcj5bKaVw2O7hVaBdBjEdQGpie4II1mWhuQ==",
 			"dev": true,
 			"requires": {
 				"js-yaml": "^3.13.1",
 				"lcov-parse": "^1.0.0",
 				"log-driver": "^1.2.7",
 				"minimist": "^1.2.5",
-				"request": "^2.88.0"
+				"request": "^2.88.2"
 			}
 		},
 		"cross-spawn": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@types/jest": "^25.1.4",
     "babel-jest": "^25.1.0",
     "babel-plugin-jsx-dom-expressions": "~0.18.0",
-    "coveralls": "^3.0.11",
+    "coveralls": "^3.1.0",
     "dom-expressions": "0.18.0",
     "hyper-dom-expressions": "0.18.0",
     "jest": "~25.1.0",


### PR DESCRIPTION
Current version of coveralls causes a build failure: 
https://travis-ci.com/github/ryansolid/solid/builds/164916703

Upgrading to the latest version should fix it: https://github.com/nickmerwin/node-coveralls/issues/280