### PR TITLE
Fix a typing issue with the Dynamic component

### DIFF
--- a/packages/solid/src/dom/index.ts
+++ b/packages/solid/src/dom/index.ts
@@ -32,7 +32,7 @@ export function Portal(props: {
 }
 
 export function Dynamic<T>(
-  props: T & { component?: Component<T> | keyof JSX.IntrinsicElements }
+  props: T & { component?: Component<T> | string | keyof JSX.IntrinsicElements }
 ): () => JSX.Element {
   const [p, others] = splitProps(props, ["component"]);
   return () => {


### PR DESCRIPTION
The `component` props of the `Dynamic` component accept a string or a Component and renders accordingly to its type. Unfortunately, Typescript is unhappy when you give it a string. This PR should fix the issue.