### PR TITLE
typo: fix solid-ssr d.ts createSSR -> createServer

### DIFF
--- a/packages/solid-ssr/server.d.ts
+++ b/packages/solid-ssr/server.d.ts
@@ -1,4 +1,4 @@
-export default function createSSR(options: {
+export default function createServer(options: {
   path: string;
   forks: number;
   maxRAM: number;


### PR DESCRIPTION
in **solid-ssr/server.js**, `createServer` is exported.

https://github.com/ryansolid/solid/blob/e24c781545720df07985ddf3f8fd121d75f2df46/packages/solid-ssr/server.js#L64

but in **solid-ssr/server.d.ts**, `createSSR` is exported.

https://github.com/ryansolid/solid/blob/e24c781545720df07985ddf3f8fd121d75f2df46/packages/solid-ssr/server.d.ts#L1



Due to this conflict,  tsc infers `createServer` as any type. I fix this.

As for the name of the module, I set it to `createServer` according to the reference in the README

https://github.com/ryansolid/solid/tree/master/packages/solid-ssr
