### PR TITLE
Add ComponentProps<T> type

### DIFF
--- a/packages/solid/src/rendering/component.ts
+++ b/packages/solid/src/rendering/component.ts
@@ -2,7 +2,16 @@ import { untrack } from "../reactive/signal";
 
 type PropsWithChildren<P> = P & { children?: JSX.Element };
 export type Component<P = {}> = (props: PropsWithChildren<P>) => JSX.Element;
-export type ComponentProps<T> = T extends Component<infer P>
+/**
+ * Takes the props of the passed component and returns its type
+ *
+ * @example
+ * ComponentProps<typeof Portal> // { mount?: Node; useShadow?: boolean; children: JSX.Element }
+ * ComponentProps<'div'> // JSX.HTMLAttributes<HTMLDivElement>
+ */
+export type ComponentProps<
+  T extends keyof JSX.IntrinsicElements | Component<any>
+> = T extends Component<infer P>
   ? P
   : T extends keyof JSX.IntrinsicElements
   ? JSX.IntrinsicElements[T]

--- a/packages/solid/src/rendering/component.ts
+++ b/packages/solid/src/rendering/component.ts
@@ -2,7 +2,12 @@ import { untrack } from "../reactive/signal";
 
 type PropsWithChildren<P> = P & { children?: JSX.Element };
 export type Component<P = {}> = (props: PropsWithChildren<P>) => JSX.Element;
-
+export type ComponentProps<T extends keyof JSX.IntrinsicElements | Component<any>> =
+        T extends Component<infer P>
+            ? P
+            : T extends keyof JSX.IntrinsicElements
+                ? JSX.IntrinsicElements[T]
+                : {};
 export function createComponent<T>(
   Comp: (props: T) => JSX.Element,
   props: T

--- a/packages/solid/src/rendering/component.ts
+++ b/packages/solid/src/rendering/component.ts
@@ -2,22 +2,23 @@ import { untrack } from "../reactive/signal";
 
 type PropsWithChildren<P> = P & { children?: JSX.Element };
 export type Component<P = {}> = (props: PropsWithChildren<P>) => JSX.Element;
-export type ComponentProps<T extends keyof JSX.IntrinsicElements | Component<any>> =
-        T extends Component<infer P>
-            ? P
-            : T extends keyof JSX.IntrinsicElements
-                ? JSX.IntrinsicElements[T]
-                : {};
-export function createComponent<T>(
-  Comp: (props: T) => JSX.Element,
-  props: T
-): JSX.Element {
+export type ComponentProps<T> = T extends Component<infer P>
+  ? P
+  : T extends keyof JSX.IntrinsicElements
+  ? JSX.IntrinsicElements[T]
+  : {};
+export function createComponent<T>(Comp: (props: T) => JSX.Element, props: T): JSX.Element {
   return untrack(() => Comp(props as T));
 }
 
 export function assignProps<T, U>(target: T, source: U): T & U;
 export function assignProps<T, U, V>(target: T, source1: U, source2: V): T & U & V;
-export function assignProps<T, U, V, W>(target: T, source1: U, source2: V, source3: W): T & U & V & W;
+export function assignProps<T, U, V, W>(
+  target: T,
+  source1: U,
+  source2: V,
+  source3: W
+): T & U & V & W;
 export function assignProps(target: any, ...sources: any): any {
   for (let i = 0; i < sources.length; i++) {
     const descriptors = Object.getOwnPropertyDescriptors(sources[i]);
@@ -34,7 +35,12 @@ export function splitProps<T extends object, K1 extends keyof T, K2 extends keyo
   props: T,
   ...keys: [K1[], K2[]]
 ): [Pick<T, K1>, Pick<T, K2>, Omit<T, K1 | K2>];
-export function splitProps<T extends object, K1 extends keyof T, K2 extends keyof T, K3 extends keyof T>(
+export function splitProps<
+  T extends object,
+  K1 extends keyof T,
+  K2 extends keyof T,
+  K3 extends keyof T
+>(
   props: T,
   ...keys: [K1[], K2[], K3[]]
 ): [Pick<T, K1>, Pick<T, K2>, Pick<T, K3>, Omit<T, K1 | K2 | K3>];


### PR DESCRIPTION
```ts
export type ComponentProps<T> = T extends Component<infer P>
  ? P
  : T extends keyof JSX.IntrinsicElements
  ? JSX.IntrinsicElements[T]
  : {};
```
It could be used in cases:
```ts
// type ParagraphProps  = JSX.HTMLAttributes<HTMLParagraphElement>
type ParagraphProps = ComponentProps<'p'>; 
/*
type PortalProps  = {
    mount?: Node | undefined;
    useShadow?: boolean | undefined;
    children: JSX.Element;
}
*/
type PortalProps = ComponentProps<typeof Portal>;
```
from react implementation: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts#L831