### PR TITLE
Inputmode on HTMLAttributes

### DIFF
--- a/packages/solid/src/rendering/jsx.ts
+++ b/packages/solid/src/rendering/jsx.ts
@@ -1962,6 +1962,7 @@ declare global {
       align?: "start" | "end" | "center" | "baseline" | "stretch" | "left" | "right";
       part?: string;
       exportparts?: string;
+      inputMode?: 'none' | 'text' | 'tel' | 'url' | 'email' | 'numeric' | 'decimal' | 'search';
     }
 
     // HTML Elements


### PR DESCRIPTION
I was missing the [inputmode](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode) attribute on an input element, and did not find it defined in the herein altered `jsx.ts` file.

Looking into DefinitelyTyped, they place it on HTMLAttributes in conformance with the specification [link](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/2e4a5dfdb17c4730d81fec3265ee7167418dfc51/types/react/index.d.ts#L1806).

A possible alternative would be to add it on `InputHTMLAttributes`. I'm not sure which global uses there are, I guess on a `contentEditable`. Possibly it could be practical to specify it just for input elements, though this would be non-conformant.

This pull-request adds `inputMode` in the same manner as DefinitelyTyped.