### PR TITLE
Mention setProperty advantage in Inline Style docs

### DIFF
--- a/documentation/styling.md
+++ b/documentation/styling.md
@@ -57,6 +57,9 @@ This also means it can support stuff like CSS variables:
 <div style={{ "--my-custom-color": state.themeColor }} />
 ```
 
+In addition to supporting CSS variables it puts things consistent with CSS string and SSR versions.
+[`setProperty`](https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleDeclaration/setProperty) is also more performant.
+
 _Note: The compiler automatically optimizes object form when declared inline unrolling any iteration._
 
 ## Classes


### PR DESCRIPTION
Just got an answer in [discord](https://discordapp.com/channels/722131463138705510/722131463889223772/765944894211751947) about why hyphenated is chosen over camel cased inline styles properties.
I believe that such info should be in the documentation :)