### PR TITLE
Change return type for renderToNodeStream

### DIFF
--- a/packages/solid/src/server/ssr.d.ts
+++ b/packages/solid/src/server/ssr.d.ts
@@ -1,4 +1,9 @@
+// forward declarations
+declare namespace NodeJS {
+  interface ReadableStream {}
+}
+
 export function renderToString<T>(fn: () => T): string;
-export function renderToNodeStream<T>(fn: () => T): ReadableStream<string>;
+export function renderToNodeStream<T>(fn: () => T): NodeJS.ReadableStream;
 export function ssr(template: string[] | string, ...nodes: any[]): { t: string };
 export function resolveSSRNode(node: any): string;


### PR DESCRIPTION
...from `ReadableStream<string>` to `NodeJS.ReadableStream`, to fix the following issue:

<img width="711" alt="Property 'pipe' does not exist on type 'ReadableStream<string>'" src="https://user-images.githubusercontent.com/640669/96113356-c24f9c00-0eec-11eb-84f8-6d9758f127b5.png">

By analogy with [DefinitelyTyped/react-dom](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react-dom/server/index.d.ts)