### PR TITLE
Fix named export resolving order

### DIFF
--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -45,6 +45,10 @@
         "import": "./web/dist/server.js",
         "require": "./web/dist/server.cjs"
       },
+      "browser": {
+        "import": "./web/dist/web.js",
+        "require": "./web/dist/web.cjs"
+      },
       "node": {
         "import": "./web/dist/server-async.js",
         "require": "./web/dist/server-async.cjs"


### PR DESCRIPTION
As I worked on my [vite-plugin-solid](https://www.npmjs.com/package/vite-plugin-solid), it came to my attention that a [certain version of Vite](https://github.com/vitejs/vite/blob/main/packages/vite/CHANGELOG.md#200-beta11-2021-01-07) broke the resolution of `solid-js/web`.

```bash
error during build:
Error: 'template' is not exported by node_modules/.pnpm/solid-js@0.23.10/node_modules/solid-js/web/dist/server-async.js, imported by node_modules/.pnpm/solid-app-router@0.0.19_solid-js@0.23.10/node_modules/solid-app-router/dist/index.jsx
```

Digging a bit, I found it to be related to this issue: [https://github.com/vitejs/vite/issues/1418](https://github.com/vitejs/vite/issues/1418). As it turn out Jason Miller is on a mission to unify bundlers to try and be spec compliant.

The way Evan You handled it in Vite is that he resolves then `browser` entry, then `node` entry and then the default `import`. Since `node` is above the defaults in the `solid-js/web` export mapping, this is the one being picked up by Vite (and supposedly other tool that follows this spec I suppose).

Therefore, I do believe that adding a `browser` entry above the `node` one should suffice to fix the issue.

I don't think it should impact anything, but I could be wrong on that one.

edit: Patching the node_modules manually, indeed fix the issue.