### PR TITLE
Change `sideEffects` from string to boolean

### DIFF
--- a/packages/solid-meta/package.json
+++ b/packages/solid-meta/package.json
@@ -15,7 +15,7 @@
   "files": [
     "dist"
   ],
-  "sideEffects": "false",
+  "sideEffects": false,
   "scripts": {
     "build": "tsc",
     "test": "jest && npm run test:types",


### PR DESCRIPTION
According to the specification of `sideEffects` which is a Webpack thing apparently, the `sideEffects` value should be either a boolean or an array of string (that represent the files operating side effects).
Although I doubt this is a deal breaker, a warning is occasionally thrown in ESBuild (via vite):
```build
 > node_modules/.pnpm/solid-meta@0.23.11_solid-js@0.23.11/node_modules/solid-meta/package.json: warning: The value for "sideEffects" must be a boolean or an array
    18 │   "sideEffects": "false",
       ╵   
```