### PR TITLE
Fix some inaccurate typings and Selector bug

### DIFF
--- a/packages/solid/src/reactive/signal.ts
+++ b/packages/solid/src/reactive/signal.ts
@@ -205,7 +205,7 @@ export function createSelector<T, U>(
     (p: T | undefined) => {
       const v = source();
       for (const key of subs.keys())
-        if (fn(key, v) || (p && fn(key, p))) {
+        if (fn(key, v) || (p !== undefined && fn(key, p))) {
           const c = subs.get(key)!;
           c.state = STALE;
           if (c.pure) Updates!.push(c);

--- a/packages/solid/src/reactive/signal.ts
+++ b/packages/solid/src/reactive/signal.ts
@@ -96,7 +96,7 @@ export function createRoot<T>(fn: (dispose: () => void) => T, detachedOwner?: Ow
   return result!;
 }
 
-export function createSignal<T>(): [() => T | undefined, (v?: T) => T];
+export function createSignal<T>(): [() => T | undefined, <U extends T | undefined>(v?: U) => U];
 export function createSignal<T>(
   value: T,
   areEqual?: boolean | ((prev: T, next: T) => boolean),
@@ -373,10 +373,12 @@ export function serializeGraph(owner?: Owner | null): GraphRecord {
 export interface Context<T> {
   id: symbol;
   Provider: (props: { value: T; children: any }) => any;
-  defaultValue?: T;
+  defaultValue: T;
 }
 
-export function createContext<T>(defaultValue?: T): Context<T> {
+export function createContext<T>(): Context<T | undefined>
+export function createContext<T>(defaultValue: T): Context<T>
+export function createContext<T>(defaultValue?: T): Context<T | undefined> {
   const id = Symbol("context");
   return { id, Provider: createProvider(id), defaultValue };
 }

--- a/packages/solid/src/reactive/signal.ts
+++ b/packages/solid/src/reactive/signal.ts
@@ -120,14 +120,20 @@ export function createSignal<T>(
   return [readSignal.bind(s), writeSignal.bind(s)];
 }
 
+export function createComputed<T>(fn: (v: T) => T, value: T): void;
+export function createComputed<T>(fn: (v?: T) => T | undefined): void;
 export function createComputed<T>(fn: (v?: T) => T, value?: T): void {
   updateComputation(createComputation(fn, value, true));
 }
 
+export function createRenderEffect<T>(fn: (v: T) => T, value: T): void;
+export function createRenderEffect<T>(fn: (v?: T) => T | undefined): void;
 export function createRenderEffect<T>(fn: (v?: T) => T, value?: T): void {
   updateComputation(createComputation(fn, value, false));
 }
 
+export function createEffect<T>(fn: (v: T) => T, value: T): void;
+export function createEffect<T>(fn: (v?: T) => T | undefined): void;
 export function createEffect<T>(fn: (v?: T) => T, value?: T): void {
   if (globalThis._$HYDRATION && globalThis._$HYDRATION.asyncSSR) return;
   runEffects = runUserEffects;

--- a/packages/solid/test/signals.spec.ts
+++ b/packages/solid/test/signals.spec.ts
@@ -2,6 +2,7 @@ import {
   createRoot,
   createSignal,
   createEffect,
+  createRenderEffect,
   createComputed,
   createDeferred,
   createMemo,
@@ -124,6 +125,49 @@ describe("Untrack signals", () => {
         setSign("mind");
         expect(temp).toBe("unpure thoughts");
         done();
+      });
+    });
+  });
+});
+
+describe("Typecheck computed and effects", () => {
+  test("No default value can return undefined", () => {
+    createRoot(() => {
+      let count = 0;
+      const [sign, setSign] = createSignal("thoughts");
+      const fn = (arg?: number) => {
+        count++;
+        sign();
+        expect(arg).toBe(undefined);
+        return arg;
+      };
+      createComputed(fn);
+      createRenderEffect(fn);
+      createEffect(fn);
+      setTimeout(() => {
+        expect(count).toBe(3);
+        setSign("update");
+        expect(count).toBe(6);
+      });
+    });
+  });
+  test("Default value never receives undefined", () => {
+    createRoot(() => {
+      let count = 0;
+      const [sign, setSign] = createSignal("thoughts");
+      const fn = (arg: number) => {
+        count++;
+        sign();
+        expect(arg).toBe(12);
+        return arg;
+      };
+      createComputed(fn, 12);
+      createRenderEffect(fn, 12);
+      createEffect(fn, 12);
+      setTimeout(() => {
+        expect(count).toBe(3);
+        setSign("update");
+        expect(count).toBe(6);
       });
     });
   });

--- a/packages/solid/test/signals.spec.ts
+++ b/packages/solid/test/signals.spec.ts
@@ -11,7 +11,9 @@ import {
   on,
   onMount,
   onCleanup,
-  onError
+  onError,
+  createContext,
+  useContext
 } from "../src";
 
 describe("Create signals", () => {
@@ -111,6 +113,17 @@ describe("Update signals", () => {
         done();
       });
     });
+  });
+  test("Set signal returns argument", () => {
+    const [_, setValue] = createSignal<number>();
+    const res1: undefined = setValue(undefined);
+    expect(res1).toBe(undefined);
+    const res2: number = setValue(12);
+    expect(res2).toBe(12);
+    const res3 = setValue(Math.random() >= 0 ? 12 : undefined);
+    expect(res3).toBe(12);
+    const res4 = setValue();
+    expect(res4).toBe(undefined);
   });
 });
 
@@ -363,3 +376,11 @@ describe("createSelector", () => {
     });
   });
 });
+
+describe("create and use context", () => {
+  test("createContext without arguments defaults to undefined", () => {
+    const context = createContext<number>()
+    const res = useContext(context);
+    expect(res).toBe<typeof res>(undefined)
+  })
+})

--- a/packages/solid/test/signals.spec.ts
+++ b/packages/solid/test/signals.spec.ts
@@ -375,6 +375,33 @@ describe("createSelector", () => {
       });
     });
   });
+
+  test("zero index", done => {
+    createRoot(() => {
+      const [s, set] = createSignal<number>(-1),
+        isSelected = createSelector<number, number>(s);
+      let count = 0;
+      const list = [
+        createMemo(() => {
+          count++;
+          return isSelected(0) ? "selected" : "no";
+        })
+      ];
+      expect(count).toBe(1);
+      expect(list[0]()).toBe("no");
+      setTimeout(() => {
+        count = 0;
+        set(0);
+        expect(count).toBe(1);
+        expect(list[0]()).toBe("selected");
+        count = 0;
+        set(-1);
+        expect(count).toBe(1);
+        expect(list[0]()).toBe("no");
+        done();
+      });
+    });
+  });
 });
 
 describe("create and use context", () => {


### PR DESCRIPTION
While using this library, I encountered a couple issues, mainly related to types.

- When an initial value is passed to `createComputed`, `createRenderEffect` or `createEffect`, the argument will always be of type `T`, never `undefined`. Additionally, when no initial value is given, there is no reason to restrict the return type to a defined value. The code can handle undefined values just fine. I added overloads to these methods to reflect this in the types.

- The setter returned by `createSignal()` accepts an optional argument, but returns a non-optional type. This is incorrect when passing undefined.

- `createContext()` creates a context with a default value of undefined. However, when used in `useContext()`, it will return a non-undefined type. This is possible because `lookup()` returns `any`. Typescript incorrectly assumed that `any` equals `T` and forgets that it could also be undefined. Therefore the inferred return type is `T`. I work around that by encoding the possible undefined in the `T` stored in `Context<>`.

- A good use case for selectors is using an array index as key. This means that the value `0` is likely to be used quite often. However, due to the use of a falsy check instead of an undefined check, passing 0 will not clean up correctly. I replaced the check with a check for `undefined`.

All these issues have corresponding tests that fail without these changes.

I only changed the types in `/src/reactive/`, not in `/src/static/`. I'm not sure if that's correct, but it seemed all overloads were missing in `/src/static/`, so I left it that way.