### PR TITLE
allow import of files directly, as an alternative to the primary export aliases

### DIFF
--- a/packages/solid/dev/package.json
+++ b/packages/solid/dev/package.json
@@ -2,6 +2,5 @@
   "name": "solid-js/dev",
   "main": "./dist/dev.cjs",
   "module": "./dist/dev.js",
-  "type": "module",
   "sideEffects": false
 }

--- a/packages/solid/h/package.json
+++ b/packages/solid/h/package.json
@@ -3,12 +3,5 @@
   "main": "./dist/h.cjs",
   "module": "./dist/h.js",
   "types": "./types/index.d.ts",
-  "type": "module",
-  "exports": {
-    ".": {
-      "import": "./dist/h.js",
-      "require": "./dist/h.cjs"
-    }
-  },
   "sideEffects": false
 }

--- a/packages/solid/html/package.json
+++ b/packages/solid/html/package.json
@@ -3,12 +3,5 @@
   "main": "./dist/html.cjs",
   "module": "./dist/html.js",
   "types": "./types/index.d.ts",
-  "type": "module",
-  "exports": {
-    ".": {
-      "import": "./dist/html.js",
-      "require": "./dist/html.cjs"
-    }
-  },
   "sideEffects": false
 }

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -52,18 +52,22 @@
       "import": "./web/dist/web.js",
       "require": "./web/dist/web.cjs"
     },
+    "./web/dist/*": "./web/dist/*",
     "./h": {
       "import": "./h/dist/h.js",
       "require": "./h/dist/h.cjs"
     },
+    "./h/dist/*": "./h/dist/*",
     "./html": {
       "import": "./html/dist/html.js",
       "require": "./html/dist/html.cjs"
     },
+    "./html/dist/*": "./html/dist/*",
     "./dev": {
       "import": "./dev/dist/dev.js",
       "require": "./dev/dist/dev.cjs"
-    }
+    },
+    "./dev/dist/*": "./dev/dist/*"
   },
   "scripts": {
     "prebuild": "rimraf dist/* types/*",

--- a/packages/solid/web/package.json
+++ b/packages/solid/web/package.json
@@ -3,16 +3,5 @@
   "main": "./dist/web.cjs",
   "module": "./dist/web.js",
   "types": "./types/index.d.ts",
-  "type": "module",
-  "exports": {
-    ".": {
-      "node": {
-        "import": "./dist/server.js",
-        "require": "./dist/server.cjs"
-      },
-      "import": "./dist/web.js",
-      "require": "./dist/web.cjs"
-    }
-  },
   "sideEffects": false
 }


### PR DESCRIPTION
…, in case someone needs to import `solid-js/web` in Node, or other issues with tools that don't understand Node ESM format