### PR TITLE
Add type for styled props and return

### DIFF
--- a/packages/solid-styled-components/src/index.d.ts
+++ b/packages/solid-styled-components/src/index.d.ts
@@ -25,7 +25,7 @@ export declare function ThemeProvider<
 >(props: T): JSX.Element;
 export declare function useTheme(): unknown;
 export declare function styled<T extends keyof JSX.IntrinsicElements>(
-  tag: T | ((props: any) => any)
+  tag: T | ((props: JSX.HTMLAttributes<JSX.IntrinsicElements[T]>) => JSX.Element)
 ): <P>(
   args_0:
     | string
@@ -51,4 +51,4 @@ export declare function styled<T extends keyof JSX.IntrinsicElements>(
         }
       ) => string | number | CSSAttribute | undefined)
   )[]
-) => (props: any) => any;
+) => (props: P & JSX.HTMLAttributes<JSX.IntrinsicElements[T]>) => JSX.Element;


### PR DESCRIPTION
Working with the styled API I missed having types in JSX code.
Example:
```ts
const PlayButton = styled('button')<{paused: boolean}>(props => ({
  background: props.paused ? 'green' : 'yellow' // <-- types work
}))

export const App = () => (
  <PlayButton
    className={`${buttonCss}`}
    paused={state.paused}
    onClick={paused.toggle}
  >
    {state.paused ? 'Start' : 'Pause'}
  </PlayButton>
) // <-- All types didn't work
```

With this change now props are typed and the return is a JSX.Element