### PR TITLE
add createGlobalStyles to solid-styled-components

### DIFF
--- a/packages/solid-styled-components/README.md
+++ b/packages/solid-styled-components/README.md
@@ -137,6 +137,28 @@ glob`
 `;
 ```
 
+### `createGlobalStyles`
+
+For a global style component, you call `createGlobalStyles` with your global tagged template.
+
+```js
+import { createGlobalStyles } from "solid-styled-components";
+
+const GlobalStyles = () => {
+  const Styles = createGlobalStyles`
+    html,
+    body {
+      background: light;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+  `;
+  return <Styles />;
+}
+```
+
 ### `Theme`
 You can set a Theme Provider (remember to use state or signals if you want it to be reactive)
 

--- a/packages/solid-styled-components/src/index.d.ts
+++ b/packages/solid-styled-components/src/index.d.ts
@@ -52,3 +52,8 @@ export declare function styled<T extends keyof JSX.IntrinsicElements>(
       ) => string | number | CSSAttribute | undefined)
   )[]
 ) => (props: P & JSX.HTMLAttributes<JSX.IntrinsicElements[T]>) => JSX.Element;
+export declare function createGlobalStyles(
+  tag: CSSAttribute | TemplateStringsArray | string,
+  ...props: Array<string | number | Function>
+): Function;
+

--- a/packages/solid-styled-components/src/index.js
+++ b/packages/solid-styled-components/src/index.js
@@ -18,6 +18,7 @@ export function useTheme() {
   return useContext(ThemeContext);
 }
 export function styled(tag) {
+  let _ctx = this || {};
   return (...args) => {
     return props => {
       const theme = useContext(ThemeContext);
@@ -26,7 +27,7 @@ export function styled(tag) {
           const pClassName = props.className,
             append = "className" in props && /^go[0-9]+/.test(pClassName);
           // Call `css` with the append flag and pass the props
-          let className = css.apply({ target: this.target, o: append, p: clone }, args);
+          let className = css.apply({ target: this.target, o: append, p: clone, g: _ctx.g }, args);
           return [pClassName, className].filter(Boolean).join(" ");
         },
         theme
@@ -49,5 +50,12 @@ export function styled(tag) {
       }
       return el;
     };
+  };
+}
+export function createGlobalStyles() {
+  const fn = styled.call({ g: 1 }, 'div').apply(null, arguments);
+  return function GlobalStyles(props) {
+    fn(props);
+    return null;
   };
 }


### PR DESCRIPTION
The `glob` method currently exported is [apparently the older way](https://github.com/cristianbote/goober#createglobalstyles) of attaching global styles with goober. The `createGlobalStyles` method provided by goober directly references its own `styled`, so this patch recreates it along with a needed update to `styled`.
