### PR TITLE
docs: improve `props` description

### DIFF
--- a/documentation/components.md
+++ b/documentation/components.md
@@ -1,6 +1,6 @@
 # Components
 
-Components in Solid are just Pascal(Capital) cased functions. Their first argument is an props object and return real DOM nodes.
+Components in Solid are just Pascal(Capital) cased functions. Their first argument is an props object and they return real DOM nodes.
 
 ```jsx
 const Parent = () => (
@@ -11,39 +11,173 @@ const Parent = () => (
   </section>
 );
 
-const Label = ({ greeting, children }) => (
+const Label = (props) => (
   <>
-    <div>{greeting}</div>
-    {children}
+    <div>{props.greeting}</div>
+    {props.children}
   </>
 );
 ```
 
-Since all nodes from JSX are actual DOM nodes the only responsibility of top level Templates/Components is appending to the DOM.
+Since all nodes from JSX are actual DOM nodes, the only responsibility of top level Templates/Components is appending to the DOM.
 
-Components also support dynamic bindings which allow you to pass values that will change. However you need to be careful to access your props inside bindings or effects if you want them to track change.
+## Props
+
+Much like React, Vue, Angular, and other frameworks, you can define properties on your components which allow a parent component to pass data to a child component. Here a parent is passing the string "Hello" to the `Label` component via a `greeting` property.
 
 ```jsx
-// Name will never update as it is destructured outside
-const StaticComponent = ({ name }) => <div>{ name }</div>
+const Parent = () => (
+  <section>
+    <Label greeting="Hello">
+      <div>John</div>
+    </Label>
+  </section>
+);
+```
 
-// Updates like you'd expect
-const DynamicComponent = props => <div>{ props.name }</div>
+In the above example, the value set on `greeting` is static, but we can also set dynamic values. For example:
 
-// Update on state.name change
-<DynamicComponent name={ state.name }/>
+```jsx
+const Parent = () => (
+  let value = Math.random().toString();
 
-// will not update on name change and pass by value
-const { name } = state;
-<DynamicComponent name={ name }/>
+  <section>
+    <Label greeting={value}>
+      <div>John</div>
+    </Label>
+  </section>
+);
+```
 
-// Still won't update even with the dynamic binding
-<StaticComponent name={ state.name }/>
+Components can access properties passed to them via a `props` argument.
+
+```jsx
+const Label = (props) => (
+  <>
+    <div>{props.greeting}</div>
+    {props.children}
+  </>
+);
+```
+
+Unlike in some other frameworks (e.g. React), you cannot use object destructuring on the `props` of a component. This is because the `props` object is, behind the scenes, a Proxy object that relies on getters to lazily retrieve values. Using object descructuring breaks the reactivity of `props`.
+
+This example shows the "correct" way of accessing props in Solidjs:
+
+```jsx
+// Here, `props.name` will update like you'd expect
+const MyComponent = props => <div>{ props.name }</div>
+```
+
+This example shows the wrong way of accessing props in Solidjs:
+
+```
+// This is bad
+// Here, `props.name` will not update (i.e. is not reactive) as it is destructured into `name`
+const MyComponent = ({ name }) => <div>{ name }</div>
+```
+
+While the props object looks like a normal object when you use it (and Typescript users will note that it is typed like a normal object), in reality it is reactive--somewhat similar to a Signal. This has a few implications.
+
+Because unlike, e.g. React, Solidjs function components are only executed once (rather than every render cycle), the following example will not work as desired.
+
+```jsx
+import { Component, createEffect, createMemo, createSignal } from 'solid-js';
+
+const BasicComponent = (props) => {
+  const value = props.value || 'default';
+
+  return <div>{value}</div>;
+};
+
+export default function Form() {
+  const [value, setValue] = createSignal('');
+
+  return (
+    <div>
+      <BasicComponent value={value()} />
+
+      <input type="text" oninput={(e) => setValue(e.currentTarget.value)} />
+    </div>
+  );
+}
+```
+
+In this example, what we probably want to happen is for the `BasicComponent` to display the current value typed into the `input`. But, as a reminder, the `BasicComponent` function will only be executed once when the component is initially mounted. At this time (i.e. when it's mounted), `props.value` will equal `''`. This means that `const value` in `BasicComponent` will resolve to `'default'` and never update. While the `props` object is reactive, accessing the props in `const value = props.value || 'default';` is outside the observable scope of Solidjs, so it isn't automatically re-evaluated when props change. 
+
+So how can we fix out problem?
+
+Well, in general, we need to access `props` somewhere that `Solidjs` can observe it. Generally this means inside JSX or inside a `createMemo`, `createEffect`, etc callback. Here is one solution that works as expected:
+
+```jsx
+const BasicComponent = (props) => {
+  return <div>{props.value || 'default'}</div>;
+};
+```
+
+Another option is to convert a prop to a Signal using `createMemo`. For example:
+
+```jsx
+const BasicComponent = (props) => {
+  const value = createMemo(() => props.value || 'default');
+
+  return <div>{value()}</div>;
+};
+```
+
+As a reminder, the following examples will _not_ work:
+
+```jsx
+// bad
+const BasicComponent = (props) => {
+  const { value: valueProp } = props;
+  const value = createMemo(() => valueProp || 'default');
+  return <div>{value()}</div>;
+};
+
+// bad
+const BasicComponent = (props) => {
+  const valueProp = prop.value;
+  const value = createMemo(() => valueProp || 'default');
+  return <div>{value()}</div>;
+};
+```
+
+Solid's Components are the key part of its performance. Solid's approach is "Vanishing" Components made possible by lazy prop evaluation. Instead of evaluating prop expressions immediately and passing in values, execution is deferred until the prop is accessed in the child. In so we defer execution until the last moment typically right in the DOM bindings maximizing performance. This flattens the hierarchy and removes the need to maintain a tree of Components.
+
+```jsx
+<Component prop1="static" prop2={state.dynamic} />
+
+// compiles roughly to:
+
+// we untrack the component body to isolate it and prevent costly updates
+untrack(() => Component({
+  prop1: "static",
+  // dynamic expression so we wrap in a getter
+  get prop2() { return state.dynamic }
+}))
+```
+
+To help maintain reactivity Solid has a couple prop helpers:
+
+```jsx
+// default props
+props = mergeProps({ name: "Smith" }, props);
+
+// clone props
+const newProps = mergeProps(props);
+
+// merge props
+props = mergeProps(props, otherProps);
+
+// split props into multiple props objects
+const [local, others] = splitProps(props, ["className"])
+<div {...others} className={cx(local.className, theme.component)} />
 ```
 
 ## Children
 
-Solid handles JSX Children similar to React. A single child is a single value on `props.children` and multiple is an array. Normally you pass them through to the JSX view. However if you want to interact with the suggested method is the `children` helper which resolves any downstream control flows and returns a memo.
+Solid handles JSX Children similar to React. A single child is a single value on `props.children` and multiple is an array. Normally you pass them through to the JSX view. However if you want to interact with them the suggested method is the `children` helper which resolves any downstream control flows and returns a memo.
 
 ```jsx
 // single child
@@ -78,40 +212,6 @@ const List = (props) => {
 ```
 
 **Important:** Solid treats child tags as expensive expressions and wraps them the same way as dynamic reactive expressions. This means they evaluate lazily on `prop` access. Be careful accessing them multiple times or destructuring before the place you would use them in the view. This is because Solid doesn't have luxury of creating Virtual DOM nodes ahead of time then diffing them so resolution of these `props` must be lazy and deliberate. Use `children` helper if you wish to do this as it memoizes them.
-
-## Props
-
-Solid's Components are the key part of its performance. Solid's approach is "Vanishing" Components made possible by lazy prop evaluation. Instead of evaluating prop expressions immediately and passing in values, execution is deferred until the prop is accessed in the child. In so we defer execution until the last moment typically right in the DOM bindings maximizing performance. This flattens the hierarchy and removes the need to maintain a tree of Components.
-
-```jsx
-<Component prop1="static" prop2={state.dynamic} />
-
-// compiles roughly to:
-
-// we untrack the component body to isolate it and prevent costly updates
-untrack(() => Component({
-  prop1: "static",
-  // dynamic expression so we wrap in a getter
-  get prop2() { return state.dynamic }
-}))
-```
-
-To help maintain reactivity Solid has a couple prop helpers:
-
-```jsx
-// default props
-props = mergeProps({ name: "Smith" }, props);
-
-// clone props
-const newProps = mergeProps(props);
-
-// merge props
-props = mergeProps(props, otherProps);
-
-// split props into multiple props objects
-const [local, others] = splitProps(props, ["className"])
-<div {...others} className={cx(local.className, theme.component)} />
-```
 
 ## Lifecycle
 


### PR DESCRIPTION
This PR attempts to improve the description of `props` in the docs by adding additional examples and a lengthier introduction. I also rearranged the `props` and `children` sections. Since children is a property on `props`, I think it makes sense to introduce `children` after introducing `props` itself.
